### PR TITLE
keyboard_teleop.cpp: avoid high CPU usage

### DIFF
--- a/src/keyboard_teleop.cpp
+++ b/src/keyboard_teleop.cpp
@@ -118,8 +118,7 @@ int main(int argc, char **argv) {
   ros::Subscriber nameSub = n.subscribe("model_name", 100, controllerNameCallback);
   while (controllerCount == 0 || controllerCount < nameSub.getNumPublishers()) {
     ros::spinOnce();
-    ros::spinOnce();
-    ros::spinOnce();
+    ros::Duration(0.5).sleep();
   }
   ros::spinOnce();
 


### PR DESCRIPTION
Sleep 0.5s while waiting for controllers to connect in order to avoid high CPU usage.