### PR TITLE
Increase Version

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <package>
   <name>webots_ros</name>
-  <version>2.1.1</version>
+  <!-- Version matches Webots version this way: (major - 2018).minor.maintenance -->
+  <version>2.1.2</version>
   <description>The ROS package containing examples for interfacing ROS with the standard ROS controller of Webots</description>
 
   <url>http://wiki.ros.org/webots_ros</url>


### PR DESCRIPTION
Increase package version and add rule to determine version.

Note that this rule will add the constraints that we have only one version of the package per Webots release, but this doesn't prevent us from creating patch releases if we find some bug in the package as ros support re-releasing the same version (it simply adds a -0, -1, etc. suffix without requiring to specify it in the package.xml).