### PR TITLE
Remove commas in default configuration

### DIFF
--- a/launch/webots.launch
+++ b/launch/webots.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="world" default="" doc="Path to the world to load"/>
-  <arg name="mode" default="realtime," doc="Startup mode"/>
-  <arg name="no_gui" default="false," doc="Start Webots with minimal GUI"/>
+  <arg name="mode" default="realtime" doc="Startup mode"/>
+  <arg name="no_gui" default="false" doc="Start Webots with minimal GUI"/>
   <node name="webots" pkg="webots_ros" type="webots_launcher.py" args="--world=$(arg world) --mode=$(arg mode) --no-gui=$(arg no_gui)" required="true"/>
 </launch>


### PR DESCRIPTION
Webots would crash on launch using the default configuration in "webots.launch" saying there's no mode called "realtime,".