### PR TITLE
Fix InterialUnit service name

### DIFF
--- a/src/complete_test.cpp
+++ b/src/complete_test.cpp
@@ -1700,7 +1700,7 @@ int main(int argc, char **argv) {
   inertial_unit_srv.request.value = 32;
   if (set_inertial_unit_client.call(inertial_unit_srv) && inertial_unit_srv.response.success) {
     ROS_INFO("Inertial_unit enabled.");
-    sub_inertial_unit_32 = n.subscribe(model_name + "/inertial_unit/roll_pitch_yaw", 1, inertialUnitCallback);
+    sub_inertial_unit_32 = n.subscribe(model_name + "/inertial_unit/quaternion", 1, inertialUnitCallback);
     callbackCalled = false;
     while (sub_inertial_unit_32.getNumPublishers() == 0 && !callbackCalled) {
       ros::spinOnce();


### PR DESCRIPTION
This change is required to be compatible with Webots R2021a.
I'm merging it directly in the `master` branch that after #44 will contain the code compatible with R2021a.