### PR TITLE
Update version

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package>
   <name>webots_ros</name>
   <!-- Version matches Webots version this way: (major - 2018).minor.maintenance -->
-  <version>3.0.0</version>
+  <version>4.0.0</version>
   <description>The ROS package containing examples for interfacing ROS with the standard ROS controller of Webots</description>
 
   <url>http://wiki.ros.org/webots_ros</url>


### PR DESCRIPTION
Version 3.0.0 is actually the last version (the corresponding release wasn't created):
```
The package(s) in upstream are version '3.0.0', but the version to be released is '2.2.0', aborting.
```