### PR TITLE
Feature `get_multiplier` api test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,6 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs messag
     lidar_get_info.srv
     lidar_get_layer_point_cloud.srv
     lidar_get_layer_range_image.srv
-    motor_get_multiplier.srv
     motor_set_control_pid.srv
     mouse_get_state.srv
     node_add_force_or_torque.srv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs messag
     lidar_get_info.srv
     lidar_get_layer_point_cloud.srv
     lidar_get_layer_range_image.srv
+    motor_get_multiplier.srv
     motor_set_control_pid.srv
     mouse_get_state.srv
     node_add_force_or_torque.srv

--- a/src/complete_test.cpp
+++ b/src/complete_test.cpp
@@ -94,7 +94,6 @@
 #include <webots_ros/field_set_vec3f.h>
 #include <webots_ros/lidar_get_frequency_info.h>
 #include <webots_ros/lidar_get_info.h>
-#include <webots_ros/motor_get_multiplier.h>
 #include <webots_ros/motor_set_control_pid.h>
 #include <webots_ros/node_add_force_or_torque.h>
 #include <webots_ros/node_add_force_with_offset.h>
@@ -2355,7 +2354,6 @@ int main(int argc, char **argv) {
   time_step_client.call(time_step_srv);
 
   ros::ServiceClient linear_motor_get_multiplier_client;
-  webots_ros::get_float get_multiplier_srv;
   linear_motor_get_multiplier_client = n.serviceClient<webots_ros::get_float>(model_name + "/linear_motor/get_multiplier");
 
   linear_motor_get_multiplier_client.call(get_multiplier_srv);

--- a/src/complete_test.cpp
+++ b/src/complete_test.cpp
@@ -94,6 +94,7 @@
 #include <webots_ros/field_set_vec3f.h>
 #include <webots_ros/lidar_get_frequency_info.h>
 #include <webots_ros/lidar_get_info.h>
+#include <webots_ros/motor_get_multiplier.h>
 #include <webots_ros/motor_set_control_pid.h>
 #include <webots_ros/node_add_force_or_torque.h>
 #include <webots_ros/node_add_force_with_offset.h>
@@ -2341,6 +2342,26 @@ int main(int argc, char **argv) {
   ROS_INFO("Max torque for rotational_motor is %f.", get_max_torque_srv.response.value);
 
   get_max_torque_client.shutdown();
+  time_step_client.call(time_step_srv);
+
+  ros::ServiceClient rotational_motor_get_multiplier_client;
+  webots_ros::get_float get_multiplier_srv;
+  rotational_motor_get_multiplier_client = n.serviceClient<webots_ros::get_float>(model_name + "/rotational_motor/get_multiplier");
+
+  rotational_motor_get_multiplier_client.call(get_multiplier_srv);
+  ROS_INFO("Multiplier for rotational_motor is %f.", get_multiplier_srv.response.value);
+
+  rotational_motor_get_multiplier_client.shutdown();
+  time_step_client.call(time_step_srv);
+
+  ros::ServiceClient linear_motor_get_multiplier_client;
+  webots_ros::get_float get_multiplier_srv;
+  linear_motor_get_multiplier_client = n.serviceClient<webots_ros::get_float>(model_name + "/linear_motor/get_multiplier");
+
+  linear_motor_get_multiplier_client.call(get_multiplier_srv);
+  ROS_INFO("Multiplier for linear_motor is %f.", get_multiplier_srv.response.value);
+
+  linear_motor_get_multiplier_client.shutdown();
   time_step_client.call(time_step_srv);
 
   ros::ServiceClient set_motor_feedback_client;

--- a/worlds/complete_test.wbt
+++ b/worlds/complete_test.wbt
@@ -86,6 +86,7 @@ Robot {
         LinearMotor {
           name "linear_motor"
           maxPosition 100
+          multiplier 1.5
         }
       ]
       endPoint Solid {
@@ -143,6 +144,7 @@ Robot {
           name "rotational_motor"
           acceleration 5
           maxVelocity 2
+          multiplier 2.5
         }
       ]
       endPoint DEF TEST2 Solid {


### PR DESCRIPTION
As mentioned [here](https://github.com/cyberbotics/webots/pull/2939#issuecomment-856507147), the ros test for `get_multiplier` api was missing.