### PR TITLE
Fix synchronization of simulation step in panoramic_view_recorder

### DIFF
--- a/worlds/panoramic_view_recorder.wbt
+++ b/worlds/panoramic_view_recorder.wbt
@@ -12,6 +12,7 @@ TexturedBackgroundLight {
 Robot {
   rotation 1 0 0 1.5707963267948966
   controller "ros"
+  controllerArgs "--synchronize"
   supervisor TRUE
 }
 Floor {


### PR DESCRIPTION
As reported in https://github.com/cyberbotics/webots/issues/3425, the viewpoint update applied in the `panoramic_view_recorder` example was jerky in R2021b because position and orientation were applied on different simulation steps.

Adding the `--synchronize` controller arguments fix this behavior and make sure that the simulation advanced only when the step is called from the ROS script.

Previous to R2021b, the `--synchronize` argument was not needed.