### PR TITLE
Remove ROS Melodic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 ## webots_ros
 
-[![Build Status](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__webots_ros__ubuntu_bionic_amd64__binary&subject=Melodic)](http://build.ros.org/job/Mbin_uB64__webots_ros__ubuntu_bionic_amd64__binary/)
 [![Build Status](http://build.ros.org/buildStatus/icon?job=Mbin_uB64__webots_ros__ubuntu_bionic_amd64__binary&subject=Noetic)](http://build.ros.org/job/Mbin_uB64__webots_ros__ubuntu_bionic_amd64__binary/)
 
 The webots_ros package contains examples for interfacing ROS nodes with the standard ROS controller of Webots.
 
 How to set-up the ROS interface in Webots:
   - https://www.cyberbotics.com/doc/guide/tutorial-9-using-ros
-  
+
 ROS tutorial for Webots:
   - https://www.cyberbotics.com/doc/guide/using-ros
 
@@ -15,15 +14,15 @@ ROS tutorial for Webots:
 ## Acknowledgement
 
 <a href="http://rosin-project.eu">
-  <img src="http://rosin-project.eu/wp-content/uploads/rosin_ack_logo_wide.png" 
+  <img src="http://rosin-project.eu/wp-content/uploads/rosin_ack_logo_wide.png"
        alt="rosin_logo" height="60" >
 </a></br>
 
-Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.  
+Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
 More information: <a href="http://rosin-project.eu">rosin-project.eu</a>
 
-<img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg" 
-     alt="eu_flag" height="45" align="left" >  
+<img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg"
+     alt="eu_flag" height="45" align="left" >
 
-This project has received funding from the European Union’s Horizon 2020  
-research and innovation programme under grant agreement no. 732287. 
+This project has received funding from the European Union’s Horizon 2020
+research and innovation programme under grant agreement no. 732287.


### PR DESCRIPTION
Consistency with this [PR from webots Github](https://github.com/cyberbotics/webots/pull/4057), where `ROS Melodic` is removed from the documentation as we will no longer support it.