### PR TITLE
Remove deprecated api `robot_get_type`

### DIFF
--- a/src/complete_test.cpp
+++ b/src/complete_test.cpp
@@ -582,18 +582,6 @@ int main(int argc, char **argv) {
   get_time_client.shutdown();
   time_step_client.call(time_step_srv);
 
-  ros::ServiceClient get_type_client = n.serviceClient<webots_ros::get_int>(model_name + "/robot/get_type");
-  webots_ros::get_int get_type_srv;
-
-  if (get_type_client.call(get_type_srv)) {
-    int type = get_type_srv.response.value;
-    ROS_INFO("Type of %s is %d.", model_name.c_str(), type);
-  } else
-    ROS_ERROR("Failed to call service get_type.");
-
-  get_type_client.shutdown();
-  time_step_client.call(time_step_srv);
-
   ros::ServiceClient robot_set_custom_data_client =
     n.serviceClient<webots_ros::set_string>(model_name + "/robot/set_custom_data");
   webots_ros::set_string robot_set_custom_data_srv;

--- a/src/robot_information_parser.cpp
+++ b/src/robot_information_parser.cpp
@@ -81,17 +81,9 @@ int main(int argc, char **argv) {
   // leave topic once it is not necessary anymore
   nameSub.shutdown();
 
-  // call get_type and get_model services to get more general information about the robot
-  ros::ServiceClient getTypeClient = n.serviceClient<webots_ros::get_int>(controllerName + "/robot/get_type");
-  webots_ros::get_int getTypeSrv;
+  // call get_model services to get more general information about the robot
   ros::ServiceClient getModelClient = n.serviceClient<webots_ros::get_string>(controllerName + "/robot/get_model");
   webots_ros::get_string getModelSrv;
-
-  getTypeClient.call(getTypeSrv);
-  if (getTypeSrv.response.value == 40)
-    ROS_INFO("This controller is on a basic robot.");
-  else
-    ROS_INFO("This controller is on a supervisor robot.");
 
   if (getModelClient.call(getModelSrv)) {
     if (!getModelSrv.response.value.empty())


### PR DESCRIPTION
As mentioned [here](https://github.com/cyberbotics/webots/issues/4121), this API no longer serves a tangible purpose and therefore can be removed