### PR TITLE
Add count to recognition objects msg

### DIFF
--- a/msg/RecognitionObjects.msg
+++ b/msg/RecognitionObjects.msg
@@ -1,2 +1,3 @@
 Header header
+uint32 count
 webots_ros/RecognitionObject[] objects


### PR DESCRIPTION
On the `Webots` side the `RecognitionObjects` msg uses a `count` variable but it is not defined on `webots_ros`