### PR TITLE
Enforce webots's clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+Language: Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignEscapedNewlines: Left
+AlignOperands: true
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 128
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:    '^<.*\.h>'
+    Priority: 1
+  - Regex:    '^<.*'
+    Priority: 2
+  - Regex:    '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+JavaScriptQuotes: Single
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 8
+UseTab: Never
+...

--- a/src/catch_the_bird.cpp
+++ b/src/catch_the_bird.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/complete_test.cpp
+++ b/src/complete_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/complete_test.cpp
+++ b/src/complete_test.cpp
@@ -167,7 +167,7 @@ static bool callbackCalled = false;
 ros::ServiceClient time_step_client;
 webots_ros::set_int time_step_srv;
 
-static bool doubleIsEqual(double value, double expected, double delta){
+static bool doubleIsEqual(double value, double expected, double delta) {
   return ((isnan(value) && isnan(expected)) || (isinf(value) && isinf(expected)) || (fabs((value) - (expected)) <= (delta)));
 }
 
@@ -307,9 +307,8 @@ void GPSSpeedVectorCallback(const geometry_msgs::PointStamped::ConstPtr &values)
   GPSSpeedVectorValues[1] = values->point.y;
   GPSSpeedVectorValues[2] = values->point.z;
 
-  ROS_INFO("GPS speed vector values are x=%f y=%f z=%f (time: %d:%d).",
-           GPSSpeedVectorValues[0], GPSSpeedVectorValues[1], GPSSpeedVectorValues[2],
-           values->header.stamp.sec, values->header.stamp.nsec);
+  ROS_INFO("GPS speed vector values are x=%f y=%f z=%f (time: %d:%d).", GPSSpeedVectorValues[0], GPSSpeedVectorValues[1],
+           GPSSpeedVectorValues[2], values->header.stamp.sec, values->header.stamp.nsec);
   callbackCalled = true;
 }
 
@@ -1062,8 +1061,7 @@ int main(int argc, char **argv) {
 
   ros::ServiceClient sampling_period_altimeter_client;
   webots_ros::get_int sampling_period_altimeter_srv;
-  sampling_period_altimeter_client =
-    n.serviceClient<webots_ros::get_int>(model_name + "/altimeter/get_sampling_period");
+  sampling_period_altimeter_client = n.serviceClient<webots_ros::get_int>(model_name + "/altimeter/get_sampling_period");
 
   altimeter_srv.request.value = 32;
   if (set_altimeter_client.call(altimeter_srv) && altimeter_srv.response.success) {
@@ -1100,7 +1098,6 @@ int main(int argc, char **argv) {
   set_altimeter_client.shutdown();
   sampling_period_altimeter_client.shutdown();
   time_step_client.call(time_step_srv);
-
 
   /////////////////////////////////
   // BATTERY SENSOR METHODS TEST //
@@ -1971,7 +1968,8 @@ int main(int argc, char **argv) {
   ros::ServiceClient enable_joystick_client = n.serviceClient<webots_ros::set_int>(model_name + "/joystick/enable");
   webots_ros::set_int enable_joystick_srv;
   ros::Subscriber sub_joystick;
-  ros::ServiceClient joystick_is_connected_client = n.serviceClient<webots_ros::get_bool>(model_name + "/joystick/is_connected");
+  ros::ServiceClient joystick_is_connected_client =
+    n.serviceClient<webots_ros::get_bool>(model_name + "/joystick/is_connected");
   webots_ros::get_bool joystick_is_connected_srv;
 
   enable_joystick_srv.request.value = 32;
@@ -2915,8 +2913,8 @@ int main(int argc, char **argv) {
         doubleIsEqual(q.w, 0.95793, 0.00001))
       ROS_INFO("Skin first bone orientation correctly received.");
     else
-      ROS_ERROR("Wrong skin first bone orientation: [%f, %f, %f, %f] instead of [-0.28698, 0.0, 0.0, 0.95793].",
-                q.x, q.y, q.z, q.w);
+      ROS_ERROR("Wrong skin first bone orientation: [%f, %f, %f, %f] instead of [-0.28698, 0.0, 0.0, 0.95793].", q.x, q.y, q.z,
+                q.w);
   } else
     ROS_ERROR("Failed to call service skin_get_bone_orientation.");
   skin_get_bone_orientation_client.shutdown();

--- a/src/e_puck_line.cpp
+++ b/src/e_puck_line.cpp
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 // line_following example
-// this example reproduce the e-puck_line_demo example
-// but uses the ROS controller on the e-puck instead.
-// The node connect to an e-puck and then uses values from its sensors
-// to follow and line and get around obstacles.
-// the duration of the example is given as argument to the node.
+// This example reproduce the e-puck_line_demo example but uses the ROS controller on the e-puck instead.
+// The node connect to an e-puck and then uses values from its sensors to follow and line and get around obstacles.
+// The duration of the example is given as argument to the node.
 
 #include "ros/ros.h"
 

--- a/src/e_puck_line.cpp
+++ b/src/e_puck_line.cpp
@@ -234,10 +234,9 @@ void ObstacleAvoidanceModule(void) {
 ////////////////////////////////////////////
 // LLM - Line Leaving Module
 //
-// Since it has no output, this routine is not completely finished. It has
-// been designed to monitor the moment while the robot is leaving the
-// track and signal to other modules some related events. It becomes active
-// whenever the "side" variable displays a rising edge (changing from -1 to 0 or 1).
+// Since it has no output, this routine is not completely finished. It has been designed to monitor the moment while the robot
+// is leaving the track and signal to other modules some related events. It becomes active whenever the "side" variable displays
+// a rising edge (changing from -1 to 0 or 1).
 
 int llm_active = FALSE, llm_inibit_ofm_speed, llm_past_side = NO_SIDE;
 int lem_reset;
@@ -281,10 +280,9 @@ void LineLeavingModule(int side) {
 ////////////////////////////////////////////
 // OFM - Obstacle Following Module
 //
-// This function just gives the robot a tendency to steer toward the side
-// indicated by its argument "side". When used in competition with OAM it
-// gives rise to an object following behavior. The output speeds are
-// stored in ofm_speed[LEFT] and ofm_speed[RIGHT].
+// This function just gives the robot a tendency to steer toward the side indicated by its argument "side". When used in
+// competition with OAM it gives rise to an object following behavior. The output speeds are stored in ofm_speed[LEFT] and
+// ofm_speed[RIGHT].
 
 int ofm_active;
 int ofm_speed[2];
@@ -311,16 +309,12 @@ void ObstacleFollowingModule(int side) {
 ////////////////////////////////////////////
 // LEM - Line Entering Module
 //
-// This is the most complex module (and you might find easier to re-program it
-// by yourself instead of trying to understand it ;-). Its purpose is to handle
-// the moment when the robot must re-enter the track (after having by-passed
-// an obstacle, e.g.). It is organized like a state machine, which state is
-// stored in "lem_state" (see LEM_STATE_STANDBY and following #defines).
-// The inputs are (i) the two lateral ground sensors, (ii) the argument "side"
-// which determines the direction that the robot has to follow when detecting
-// a black line, and (iii) the variable "lem_reset" that resets the state to
-// standby. The output speeds are stored in lem_speed[LEFT] and
-// lem_speed[RIGHT].
+// This is the most complex module (and you might find easier to re-program it by yourself instead of trying to understand it
+// ;-). Its purpose is to handle the moment when the robot must re-enter the track (after having by-passed an obstacle, e.g.).
+// It is organized like a state machine, which state is stored in "lem_state" (see LEM_STATE_STANDBY and following #defines).
+// The inputs are (i) the two lateral ground sensors, (ii) the argument "side" which determines the direction that the robot has
+// to follow when detecting a black line, and (iii) the variable "lem_reset" that resets the state to standby. The output speeds
+// are stored in lem_speed[LEFT] and lem_speed[RIGHT].
 
 int lem_active;
 int lem_speed[2];

--- a/src/e_puck_line.cpp
+++ b/src/e_puck_line.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/keyboard_teleop.cpp
+++ b/src/keyboard_teleop.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/panoramic_view_recorder.cpp
+++ b/src/panoramic_view_recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/panoramic_view_recorder.cpp
+++ b/src/panoramic_view_recorder.cpp
@@ -21,9 +21,9 @@
 #include <webots_ros/get_uint64.h>
 #include <webots_ros/set_int.h>
 
+#include <webots_ros/field_get_name.h>
 #include <webots_ros/field_get_node.h>
 #include <webots_ros/field_get_rotation.h>
-#include <webots_ros/field_get_name.h>
 #include <webots_ros/field_get_vec3f.h>
 #include <webots_ros/field_set_rotation.h>
 #include <webots_ros/field_set_vec3f.h>

--- a/src/pr2_beer.cpp
+++ b/src/pr2_beer.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
- * Description:   controller for the PR2 to grab a can in a fridge and serve it
+ * Description: controller for the PR2 to grab a can in a fridge and serve it
  */
 
 #include <signal.h>

--- a/src/pr2_beer.cpp
+++ b/src/pr2_beer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/robot_information_parser.cpp
+++ b/src/robot_information_parser.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2020 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
To avoid inconsistencies in the style between webots and this repo, we should enforce the same rules (especially annoying if you have "formatOnSave" enabled).