### PR TITLE
Prepare 2022.1.0 release

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 <package>
   <name>webots_ros</name>
-  <!-- Version matches Webots version this way: (major - 2018).minor.maintenance -->
-  <version>5.0.1</version>
+  <!-- Before 2022.1.0: Version matches Webots version this way: (major - 2018).minor.maintenance -->
+  <!-- From 2022.1.0: Version matches Webots version this way: year.minor.maintenance -->
+  <version>2022.1.0</version>
   <description>The ROS package containing examples for interfacing ROS with the standard ROS controller of Webots</description>
 
   <url>http://wiki.ros.org/webots_ros</url>


### PR DESCRIPTION
- Update version in `package.xml` to `2022.1.0`.
- Update comment to new version format.